### PR TITLE
BREAKING: stop publishing to Docker Hub (GHCR only) + migrate build to shared bake reusable

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,9 +1,14 @@
 name: Docker
 
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
+# Build, publish and sign the container image.
+#
+# Every step lives in the shared reusable workflow
+# netresearch/.github/.github/workflows/build-container-bake.yml — this file
+# only supplies configuration. The build itself is driven by docker-bake.hcl.
+#
+# NOTE: as of this workflow, the image is published to GitHub Container
+# Registry ONLY. The Docker Hub mirror (docker.io/netresearch/docker-mariadb)
+# is no longer updated.
 
 on:
   schedule:
@@ -13,87 +18,44 @@ on:
   pull_request:
     branches: [ master ]
 
-env:
-  # Use docker.io for Docker Hub if empty
-  REGISTRY: ghcr.io
-  # github.repository as <account>/<repo>
-  IMAGE_NAME: ${{ github.repository }}
-
+permissions: {}
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
+    uses: netresearch/.github/.github/workflows/build-container-bake.yml@main
+    # A called workflow's job permissions are validated statically at startup,
+    # so the caller must grant the union of everything the reusable declares —
+    # including security-events: write, even with scan disabled.
     permissions:
       contents: read
       packages: write
-      # This is used to complete the identity challenge
-      # with sigstore/fulcio when running outside of PRs.
+      security-events: write
       id-token: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      # Install the cosign tool except on PR
-      # https://github.com/sigstore/cosign-installer
-      - name: Install cosign
-        if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
-      # Workaround: https://github.com/docker/build-push-action/issues/461
-      - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
-      # Login against a Docker registry except on PR
-      # https://github.com/docker/login-action
-      - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Log in to Docker Hub
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      # Extract metadata (tags, labels) for Docker
-      # https://github.com/docker/metadata-action
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
-        with:
-          images: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-            ${{ env.IMAGE_NAME }}
-          flavor: |
-            latest=true
-
-      # Build and push Docker image with Buildx (don't push on PR)
-      # https://github.com/docker/build-push-action
-      - name: Build and push Docker image
-        id: build-and-push
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-
-      # Sign the resulting Docker image digest except on PRs.
-      # This will only write to the public Rekor transparency log when the Docker
-      # repository is public to avoid leaking data.  If you would like to publish
-      # transparency data even for private images, pass --force to cosign below.
-      # https://github.com/sigstore/cosign
-      - name: Sign the published Docker image
-        if: ${{ github.event_name != 'pull_request' }}
-        env:
-          COSIGN_EXPERIMENTAL: "true"
-        # This step uses the identity token to provision an ephemeral certificate
-        # against the sigstore community Fulcio instance.
-        run: cosign sign --yes ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-and-push.outputs.digest }}
+    with:
+      targets: app
+      # metadata-action writes its tag/label bake files to local $RUNNER_TEMP
+      # paths; without this, bake would build from the git remote context and
+      # fail to find them.
+      bake-source: "."
+      registry: ghcr.io
+      metadata-images: ghcr.io/${{ github.repository }}
+      # Reproduces metadata-action's default tag set plus the previous
+      # `flavor: latest=true` (type=raw has the lowest priority, so `latest`
+      # stays a secondary tag and the OCI version label is unchanged).
+      metadata-tags: |
+        type=schedule
+        type=ref,event=branch
+        type=ref,event=tag
+        type=ref,event=pr
+        type=raw,value=latest
+      push: ${{ github.event_name != 'pull_request' }}
+      # Cosign keyless (OIDC) signing, as before. Only runs when push is true.
+      sign: true
+      # Container scanning already runs in ci.yml (docker-image-ci ->
+      # build-container, scan: true); the publish workflow never scanned.
+      scan: false
+      # The nightly run exists to pick up a fresh `FROM mariadb` base image and
+      # the apt upgrade layer. With the GHA layer cache it would restore the
+      # previous layer chain and rebuild nothing, turning that refresh into a
+      # no-op — so cache is off for scheduled runs only.
+      cache: ${{ github.event_name != 'schedule' }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -48,14 +48,19 @@ jobs:
         type=ref,event=tag
         type=ref,event=pr
         type=raw,value=latest
+      # An explicit tag list leaves metadata-action's flavor at `latest=auto`,
+      # which appends `latest` again on a tag push. The explicit type=raw above
+      # already reproduces the previous `flavor: latest=true` on every event,
+      # so turn the implicit one off to emit exactly one `latest`.
+      metadata-flavor: latest=false
       push: ${{ github.event_name != 'pull_request' }}
       # Cosign keyless (OIDC) signing, as before. Only runs when push is true.
       sign: true
       # Container scanning already runs in ci.yml (docker-image-ci ->
       # build-container, scan: true); the publish workflow never scanned.
       scan: false
-      # The nightly run exists to pick up a fresh `FROM mariadb` base image and
-      # the apt upgrade layer. With the GHA layer cache it would restore the
-      # previous layer chain and rebuild nothing, turning that refresh into a
-      # no-op — so cache is off for scheduled runs only.
-      cache: ${{ github.event_name != 'schedule' }}
+      # Cache only on pull_request. Any run that PUBLISHES must rebuild for
+      # real: with cache-from a push build restores the layer chain from
+      # before the nightly's `apt upgrade`, and would overwrite `:latest` /
+      # `:master` with a LESS patched image than the nightly just published.
+      cache: ${{ github.event_name == 'pull_request' }}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,25 @@
+# Bake definition for the MariaDB image.
+#
+# The tag/label scheme is NOT hardcoded here: CI runs docker/metadata-action,
+# which generates two bake files populating the `docker-metadata-action`
+# target below (tags + OCI labels). Every real target inherits that stub, so
+# the tags always come from the workflow's `metadata-tags` configuration.
+#
+# Local use:
+#   docker buildx bake            # builds `app`, untagged
+#   docker buildx bake --print    # inspect the resolved definition
+
+# Stub populated at build time by docker/metadata-action's generated bake
+# files. Never add tags to a target that inherits it — they would be
+# overridden by (or fight with) the generated definition.
+target "docker-metadata-action" {}
+
+target "app" {
+  inherits   = ["docker-metadata-action"]
+  context    = "."
+  dockerfile = "Dockerfile"
+}
+
+group "default" {
+  targets = ["app"]
+}


### PR DESCRIPTION
## ⚠️ Breaking: Docker Hub publishing stops

**`docker.io/netresearch/docker-mariadb` will no longer receive updates.**

This repo currently pushes the *same digest* to both `ghcr.io/netresearch/docker-mariadb`
and `docker.io/netresearch/docker-mariadb`. The Docker Hub repository is public and has
**18,725 pulls** (verified via the Docker Hub API today; its `last_updated` was this
morning's nightly run). This PR drops the `docker.io` image name and the second
`docker/login-action`, so:

- Everyone doing `docker pull netresearch/docker-mariadb` (`:latest`, `:master`, `:nightly`)
  keeps getting the **image published before this PR merges, frozen forever** — no more
  base-image refreshes, no more OS security patches.
- All future builds land on `ghcr.io/netresearch/docker-mariadb` only.
- This is user-visible and effectively irreversible for consumers who never notice:
  nothing errors, the image just silently stops ageing.

This is an explicit owner decision, not a side effect of the migration. It also happens to
be the only shape the shared reusable supports — `build-container-bake.yml` logs into
exactly one registry (`registry:` input), so a dual-registry push is not reproducible
through it.

### Recommended follow-up (deliberately NOT done in this PR)

1. Mark the Docker Hub repository **deprecated**: push a final README/overview to
   `netresearch/docker-mariadb` on Docker Hub saying the image is unmaintained and pointing
   at `ghcr.io/netresearch/docker-mariadb`. Nothing in this repo pushes the Hub description,
   so this is a manual step in the Docker Hub UI.
2. Delete the now-unused `DOCKER_USERNAME` / `DOCKER_PASSWORD` repository secrets.
3. Consider announcing the move before merging — ~18.7k pulls implies real consumers.

---

## What else changed: zero step-level actions

`docker-publish.yml` had 7 step-level `uses:` (checkout, cosign-installer, setup-buildx,
2× login-action, metadata-action, build-push-action). It now has **none** — one job calls
`netresearch/.github/.github/workflows/build-container-bake.yml@main`, and the build is
described by a new `docker-bake.hcl`.

### Before / after

| Behaviour | Before | After | Same? |
|---|---|---|---|
| Registries pushed | ghcr.io **and** docker.io | ghcr.io only | ❌ **intentional (above)** |
| GHCR tags, push to `master` | `master`, `latest` | `master`, `latest` | ✅ verified |
| GHCR tags, `schedule` | `nightly`, `master`, `latest` | `nightly`, `master`, `latest` | ✅ verified |
| GHCR tags, `pull_request` (built, not pushed) | `pr-N`, `latest` | `pr-N`, `latest` | ✅ verified |
| OCI labels incl. `org.opencontainers.image.version` | metadata-action defaults | identical (`master`/`nightly`/`pr-N`) | ✅ verified |
| Push on PR | no | no | ✅ |
| Signing mechanism | cosign **keyless OIDC** (`COSIGN_EXPERIMENTAL=true`, `id-token: write`, `cosign sign --yes …@digest`, no `--key`) | cosign keyless OIDC via `sign: true` | ✅ |
| Signed reference | the pushed **digest**, once | every **tag** from `bake --print` (`:master`, `:latest`) | ⚠️ differs, see below |
| Build platform | runner default (`linux/amd64`; no `platforms:` set) | unchanged (no platform in HCL or workflow) | ✅ |
| Provenance / SBOM | buildx defaults | unchanged — `attest`/`sbom` left at reusable default `false` | ✅ |
| Layer cache | none | GHA cache on push/PR, **off on `schedule`** | ⚠️ new, see below |
| Trivy scan | none | none (`scan: false`) | ✅ |
| Job permissions | contents:read, packages:write, id-token:write | + `security-events: write` | ⚠️ required, see below |
| Triggers | schedule `16 14 * * *`, push/PR on `master` | unchanged | ✅ |

### Intentional deltas, spelled out

1. **Docker Hub dropped** — see the top section.
2. **Signing target: tags instead of digest.** The reusable enumerates tags from
   `docker buildx bake --print` and runs `cosign sign --yes <tag>` for each. Cosign resolves
   the tag to its digest and stores the signature at the digest, so the end state is
   equivalent — but it is a tag→digest resolution *after* the push rather than the digest
   the build returned, and it signs the same digest twice (once via `:master`, once via
   `:latest`). Harmless here, but it is not literally the old digest-pinned command.
3. **Layer cache is new.** Today there is no cache at all — every build is a full rebuild.
   The reusable defaults `cache: true`; this PR passes
   `cache: ${{ github.event_name != 'schedule' }}`. Rationale: the nightly run exists to pull
   a fresh `FROM mariadb` (unpinned floating tag) and re-run the `apt-get upgrade` layer —
   with `cache-from` it would restore the old layer chain and rebuild nothing, silently
   turning that security refresh into a no-op. Push/PR runs keep the cache for speed.
   There is no `workflow_dispatch` trigger here, so nothing to special-case for it; if one
   is added later it should be treated like `schedule`.
   *For strict parity instead, set `cache: false` — push builds would then also always
   re-resolve `FROM mariadb`.*
4. **`security-events: write` added to the calling job.** A called workflow's job
   permissions are validated statically at workflow startup, before any `if:` — the caller
   must grant the union of everything `build-container-bake.yml` declares, or the run fails
   with `startup_failure`. Granted even though `scan: false`.
5. **`scan: false`.** This workflow never scanned, and container scanning already runs in
   `ci.yml` (`docker-image-ci.yml` → `build-container.yml`, `scan: true`) on push and PR.
   Flip to `true` if you also want the nightly rebuild scanned — the permission is in place.
6. **Two unused build args appear.** metadata-action's tag bake file injects
   `DOCKER_META_IMAGES` / `DOCKER_META_VERSION` as build args; the Dockerfile does not
   declare them, so BuildKit emits an "unused build arg" warning. Cosmetic.

### Explicitly *not* added

- **GitHub-issued SLSA attestation.** `attest: true` on the bake reusable is buildx
  `provenance=mode=max` (in-image BuildKit attestation) — a *different* mechanism from
  `actions/attest-build-provenance`. This repo has neither today, so neither was added.
  If `gh attestation verify`-able provenance is wanted, add a second job calling
  `netresearch/.github/.github/workflows/attest-image.yml@main` with the `bake-metadata`
  output and `attestations: write`.
- **Multi-arch.** Today's build is single-platform by omission; the HCL declares no
  `platforms`, preserving that. Adding arm64 is a separate decision.
- **README changes.** Nothing in the README states where to pull from, so no doc claim
  becomes false. (Unrelated pre-existing observation, not touched: both microbadger badges
  at the top are dead — `images.microbadger.com` no longer resolves.)

## How this was verified

- **Tag/label parity — measured, not reasoned.** Ran the pinned `docker/metadata-action`
  v6.2.0 dist (`dc80280…`, confirmed via the API to be the v6.2.0 tag object) locally under
  node, with synthesised `push` / `schedule` / `pull_request` contexts for this repo: once
  with the old config (2 images, default tags, `flavor: latest=true`) and once with the new
  one (ghcr only, explicit `metadata-tags`). The GHCR tag lists and the `version` output
  (which drives `org.opencontainers.image.version`) match exactly for all three events;
  only the `docker.io/...` lines disappear. `type=raw` has the lowest priority (200), so
  `latest` stays a secondary tag exactly as `flavor: latest=true` produced it.
- **Bake stub inheritance.** Fed the *actual* `docker-metadata-action-bake-tags.json` and
  `-bake-labels.json` that run wrote into
  `docker buildx bake -f docker-bake.hcl -f <tags> -f <labels> app --print`, together with
  the `--set *.cache-from/cache-to` overrides the reusable applies. The `app` target
  resolves with the expected tags, labels and cache config.
- **Sign/scan enumeration.** Replayed the reusable's `jq` over that `--print` output:
  `SIGN_TAGS` = `:master` + `:latest`, `SCAN_REFS` = `:master`.
- **The bake file actually builds.** `docker buildx bake -f docker-bake.hcl app` completed
  locally against the current Dockerfile (exit 0, image exported).
- **`actionlint .github/workflows/docker-publish.yml`** → clean, exit 0.
- **The PR's own run.** `build / Build Container (Bake)` on this PR succeeded (no
  `startup_failure`, so the permission union is right), built the `app` target, and the
  enumerate step resolved exactly `ghcr.io/netresearch/docker-mariadb:pr-45` and
  `:latest` — matching the locally predicted `pull_request` tag set. Nothing was pushed
  (`push: false` on PRs) and no `docker.io/...` reference appears anywhere in the run.
- **Read in full before writing:** the old workflow, `build-container-bake.yml`,
  `attest-image.yml`, and `ci.yml` (to confirm scanning is already covered).
- **Not verified:** `yamllint` is broken in this environment (missing module), so YAML style
  lint was not run — `lint-yaml` in `ci.yml` covers it. The live push + cosign path cannot
  be exercised outside Actions; it is inherited unchanged from the reusable.


---

## Review follow-up (owner decisions)

### Base-image pulls become unauthenticated — accepted

Removing the `docker.io` login also removed **authenticated Docker Hub pulls** of the
`FROM mariadb` base image, not just the push. Anonymous pulls are subject to Docker Hub's
stricter anonymous rate limit, so a busy build day can intermittently fail with
`toomanyrequests`.

The owner has **accepted this trade-off** rather than expanding the shared reusable with a
pull-registry credentials interface, or mirroring the base image into GHCR. If rate limiting
turns out to bite in practice, those two options remain open — the second is the durable fix.

### Credential removal — check before deleting

An org-wide code search finds `DOCKER_PASSWORD` referenced by **this repository only**, so the
`DOCKER_USERNAME` / `DOCKER_PASSWORD` org secrets look unused after this merge. That search
can miss dynamic references, so confirm before deleting them rather than treating this as
proof.

### Two review findings fixed

| Finding | Fix |
|---|---|
| `latest` was emitted **twice** on a tag push — an explicit `metadata-tags` list leaves `flavor` at `latest=auto`, which appends `latest` on top of the explicit `type=raw,value=latest` | `metadata-flavor: latest=false`, using the input added in netresearch/.github#267. Exactly one `latest` now. |
| A cached `push` build could publish a **less patched** image than the nightly had just published: the nightly rebuilds uncached to pick up `apt upgrade`, but a following cached push restored the pre-upgrade layer chain and overwrote `:latest`/`:master` | `cache` limited to `pull_request`. Every run that publishes now rebuilds for real. |

Not verified here: neither the schedule nor the tag-push path can be exercised from a pull
request, so both changes are established by reading the reusable's `Compose bake --set
overrides` step and metadata-action's flavor handling, not by execution.
